### PR TITLE
fix(scrollview): change scrollview offset snapping

### DIFF
--- a/README-24i.md
+++ b/README-24i.md
@@ -49,3 +49,8 @@ It's important to list all changes we have done in order to keep track of them a
 ### ./tvos-types.d.ts
 
 - Adding long press events for arrow keys in order to support https://jira.24i.com/browse/PRDPLAYER-1152 ([link to PR](https://github.com/24i/react-native-tvos/pull/2))
+
+
+### ./React/Views/ScrollView/RCTScrollView.m
+
+- Changed how snapping to offset is being calculated. Ticket related https://aferian.atlassian.net/browse/PRDSAPPSTV-675. ([link to PR](https://github.com/24i/react-native-tvos/pull/3))

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -717,10 +717,24 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
         // snap to beginning
         targetOffset = firstOffset;
       }
-    } else if (velocityAlongAxis > 0.0) {
-      targetOffset = largerOffset;
-    } else if (velocityAlongAxis < 0.0) {
-      targetOffset = smallerOffset;
+    //
+    // This has been changed in order to fix how scrolling happens on tvos
+    // tvOS is adding exactly 80 pixels offset when scrolling probably to
+    // make sure user knows there are more items to scroll. In many cases
+    // this behavior is not what we want and is causing unaligned items.
+    //
+    // https://aferian.atlassian.net/browse/PRDSAPPSTV-675
+    //
+    // Old implementation:
+    //
+    // } else if (velocityAlongAxis > 0.0) {
+    //   targetOffset = largerOffset;
+    // } else if (velocityAlongAxis < 0.0) {
+    //   targetOffset = smallerOffset;
+    // } else {
+    //   targetOffset = nearestOffset;
+    // }
+    //
     } else {
       targetOffset = nearestOffset;
     }


### PR DESCRIPTION
## Related ticket

https://aferian.atlassian.net/browse/PRDSAPPSTV-675

## Summary

Changed how scrollview snapping works. I'm not sure if the current core feature is a bug or something, but it doesn't suit super well with tvOS UX. This change is best explained with visual presentation.

The change in a nutshell:

![snapping-explained](https://github.com/24i/react-native-tvos/assets/94367434/24e5447b-027b-461f-8c97-272b26e5eadc)


## In practice

This is the starting point:

<img width="1600" alt="Screenshot 2023-08-04 at 9 38 16" src="https://github.com/24i/react-native-tvos/assets/94367434/1e81df33-8599-430e-9f2a-29d50fdb6fdc">

As you can see, rows are not aligned. Naturally UIScrollView seems to add 80 pixel offset to the scrollview when there are items on the left side to scroll to. I suppose this is to make sure user knows they can scroll there. For us this is unnecessary behavior. In order to fix this we'll start by defining `snapToOffsets` property on `<FlatList />` within the `<FocusSection />` code. The result will look like this:

<img width="1598" alt="Screenshot 2023-08-04 at 9 45 30" src="https://github.com/24i/react-native-tvos/assets/94367434/d1a8de77-3912-4eaa-9047-49f139b45ac9">

Under the hood React Native handles `snapToOffsets` in a way that in a `scrollViewWillEndDragging` hook on UIScrollView it will modify targetOffset (the point to scroll to) in a way that it matches one of the snapToOffsets value. The problem is that the calculation is not perfect. As you can see from the image, focused item is not on the left side of the screen. It's off by one. The reason for this is the current calculation of snapToOffsets logic (see the first attached image).

So this PR fixes this and the result is this:

<img width="1594" alt="Screenshot 2023-08-04 at 9 51 25" src="https://github.com/24i/react-native-tvos/assets/94367434/acf94ceb-0ed7-4a15-b04b-fbfd71107520">

And now the scrolling works as expected. Focused item is aligned correctly on the left side of the screen.