### PR TITLE
fix: touch handling

### DIFF
--- a/README-24i.md
+++ b/README-24i.md
@@ -64,3 +64,11 @@ It's important to list all changes we have done in order to keep track of them a
 ### ./React/Views/ScrollView/RCTScrollView.m
 
 - Changed how snapping to offset is being calculated. Ticket related https://aferian.atlassian.net/browse/PRDSAPPSTV-675. ([link to PR](https://github.com/24i/react-native-tvos/pull/3))
+
+### ./React/Base/RCTTouchHandler.m
+
+- Changed how touch events are bubbling. It affects swipe. 
+This is needed when used in conjuction with "react-native-screens": "3.13.1"
+Remove if updating it.
+Ticket related https://aferian.atlassian.net/browse/PRDSAPPSTV-751
+Ticket related https://aferian.atlassian.net/browse/PRDSAPPSRN-12649

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -338,7 +338,22 @@ static BOOL RCTAnyTouchesChanged(NSSet<UITouch *> *touches)
 {
   // We fail in favour of other external gesture recognizers.
   // iOS will ask `delegate`'s opinion about this gesture recognizer little bit later.
-  return ![preventingGestureRecognizer.view isDescendantOfView:self.view];
+  
+  // IMPORTANT
+  // return ![preventingGestureRecognizer.view isDescendantOfView:self.view];
+
+  // Why is this override here
+  // https://aferian.atlassian.net/browse/PRDSAPPSTV-751
+  // Somehow on tvOS 17 the focus is lost when we use React-Native-Screens 3.13.1
+    #if TARGET_OS_TV
+        if (@available(tvOS 17.0, *)) {
+            return NO;
+        } else {
+            return ![preventingGestureRecognizer.view isDescendantOfView:self.view];
+        }
+    #else
+      return ![preventingGestureRecognizer.view isDescendantOfView:self.view];
+    #endif
 }
 
 - (void)reset


### PR DESCRIPTION
## Summary:

Changed how touch events are bubbling. It affects swipe. 
This is needed when used in conjuction with "react-native-screens": "3.13.1"